### PR TITLE
add zoom-in fade-in slide-down effects

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -206,11 +206,18 @@ article {
 }
 
 #cache {
-  display: none;
+  /* display: none; */
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 2.6s ease-out, opacity 2.6s ease-out, padding 2.6s ease-out;
 }
 
 #cache:target {
-  display: block;
+  /* display: block; */
+  max-height: 200vh; /* Une valeur suffisamment grande pour le contenu */
+  opacity: 1;
+  overflow: inherit;
 }
 
 /*--------------------------------------------------------
@@ -530,6 +537,15 @@ div.bouton_commande:nth-child(n) > a:nth-child(1) {
   border-radius: 10px 10px;
   justify-content: flex-start;
   padding: 1px 1px 5px 1px;
+  opacity: 0; /* Invisible au départ */
+  transform: translateY(25px) scale(0.9); /* Décalé vers le bas et réduit */
+  transition: opacity 0.7s ease-out, transform 0.7s ease-out;
+}
+
+ /* 🔹 Quand l'article est visible */
+ .top_article-visible {
+  opacity: 1;
+  transform: translateY(0) scale(1); /* Reprend sa taille normale */
 }
 
 .ico_categorie {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,4 +1,11 @@
 document.addEventListener('DOMContentLoaded', function () {
+
+  // Transition fluide effet
+  let article = document.querySelector(".top_article");
+  setTimeout(() => {
+    article.classList.add("top_article-visible");
+  }, 200); // Petit délai pour un effet plus fluide de 200ms
+
   // Recaptcha
   if (document.getElementById('recaptchaResponse')) {
     grecaptcha.ready(function () {
@@ -11,6 +18,7 @@ document.addEventListener('DOMContentLoaded', function () {
         })
     })
   }
+
   // Ckeditor
   ClassicEditor.create(document.querySelector('#editor')).catch((error) => {
     // console.error(error)
@@ -24,11 +32,11 @@ document.addEventListener('DOMContentLoaded', function () {
     btnCriteria.setAttribute('value', 'Plus de critères')
     btnCriteria.addEventListener('click', (e) => {
       e.stopPropagation()
-      if(isHided){
+      if (isHided) {
         btnCriteria.removeAttribute('value')
         btnCriteria.setAttribute('value', 'Moins de critères')
         isHided = false
-      }else{
+      } else {
         btnCriteria.removeAttribute('value')
         btnCriteria.setAttribute('value', 'Plus de critères')
         isHided = true
@@ -37,5 +45,5 @@ document.addEventListener('DOMContentLoaded', function () {
         criteria.classList.toggle('switch')
       })
     })
-  }  
+  }
 })


### PR DESCRIPTION
opacity: 0 → L'article est invisible au début.
translateY(25px) scale(0.95) → Il commence légèrement plus bas et plus petit.
transition: opacity 0.7s ease-out, transform 0.7s ease-out → Animation douce.

    Quand la classe .article-visible est ajoutée, l'article reprend sa taille et devient visible.
Petit setTimeout(200ms) → Pour rendre l'effet plus naturel.

L'article apparaît en douceur, en remontant et en grossissant légèrement pour un effet moderne et élégant.